### PR TITLE
Renderer#renderX() to render()

### DIFF
--- a/src/com/wasd/lib3d/rendering/Renderer.java
+++ b/src/com/wasd/lib3d/rendering/Renderer.java
@@ -37,34 +37,34 @@ public class Renderer {
             DrawableDot dotted = (DrawableDot)drawable;
 
             int size = Math.round(dotted.getSize());
-            Float2 pixel = relativeToAbsolutePixels(dotted.getLocationOnScreen());
+            Float2 positionPixel = relativeToAbsolutePixels(dotted.getLocationOnScreen());
 
             if(drawable instanceof DrawableText){
-                renderText(((DrawableText) drawable).getText(), size, pixel);
+                renderText(((DrawableText) drawable).getText(), size, positionPixel);
             } else {
-                renderDot(size, pixel);
+                renderDot(size, positionPixel);
             }
         }
     }
 
     private void renderLine(DrawableLine drawableLine) {
-        Float2 pixel1 = relativeToAbsolutePixels(drawableLine.getStartLocationOnScreen());
-        Float2 pixel2 = relativeToAbsolutePixels(drawableLine.getEndLocationOnScreen());
+        Float2 positionPixel1 = relativeToAbsolutePixels(drawableLine.getStartLocationOnScreen());
+        Float2 positionPixel2 = relativeToAbsolutePixels(drawableLine.getEndLocationOnScreen());
 
-        graphics.drawLine(Math.round(pixel1.x), Math.round(pixel1.y),
-                Math.round(pixel2.x), Math.round(pixel2.y));
+        graphics.drawLine(Math.round(positionPixel1.x), Math.round(positionPixel1.y),
+                Math.round(positionPixel2.x), Math.round(positionPixel2.y));
     }
 
-    private void renderDot(int dotDrawSize, Float2 pixel) {
-        graphics.fillOval(Math.round(pixel.x - dotDrawSize / 2f), Math.round(pixel.y - dotDrawSize / 2f),
+    private void renderDot(int dotDrawSize, Float2 positionPixel) {
+        graphics.fillOval(Math.round(positionPixel.x - dotDrawSize / 2f), Math.round(positionPixel.y - dotDrawSize / 2f),
                 dotDrawSize, dotDrawSize);
     }
 
-    private void renderText(String text, int fontSize, Float2 pixel) {
+    private void renderText(String text, int fontSize, Float2 positionPixel) {
         //TODO http://stackoverflow.com/questions/27706197/how-can-i-center-graphics-drawstring-in-java
 
         graphics.setFont(createFont(fontSize));
-        graphics.drawString(text, Math.round(pixel.x), Math.round(pixel.y));
+        graphics.drawString(text, Math.round(positionPixel.x), Math.round(positionPixel.y));
     }
 
     private Font createFont(int fontSize) {

--- a/src/com/wasd/lib3d/rendering/Renderer.java
+++ b/src/com/wasd/lib3d/rendering/Renderer.java
@@ -24,48 +24,47 @@ public class Renderer {
         centerY = height / 2;
     }
 
-    public void renderLine(DrawableLine drawableLine) {
-        Color c = colorBasedOnDistance(drawableLine);
-        if (c == null) {
+    public void render(Drawable drawable){
+        Color color = colorBasedOnDistance(drawable);
+        if (color == null) {
             return;
         }
+        graphics.setColor(color);
 
+        if(drawable instanceof DrawableLine){
+            renderLine((DrawableLine) drawable);
+        } else if(drawable instanceof DrawableDot){
+            DrawableDot dotted = (DrawableDot)drawable;
+
+            int size = Math.round(dotted.getSize());
+            Float2 pixel = relativeToAbsolutePixels(dotted.getLocationOnScreen());
+
+            if(drawable instanceof DrawableText){
+                renderText(((DrawableText) drawable).getText(), size, pixel);
+            } else {
+                renderDot(size, pixel);
+            }
+        }
+    }
+
+    private void renderLine(DrawableLine drawableLine) {
         Float2 pixel1 = relativeToAbsolutePixels(drawableLine.getStartLocationOnScreen());
         Float2 pixel2 = relativeToAbsolutePixels(drawableLine.getEndLocationOnScreen());
 
-        graphics.setColor(c);
         graphics.drawLine(Math.round(pixel1.x), Math.round(pixel1.y),
                 Math.round(pixel2.x), Math.round(pixel2.y));
     }
 
-    public void renderDot(DrawableDot drawableDot) {
-        int dotDrawSize = Math.round(drawableDot.getSize());
-        Color c = colorBasedOnDistance(drawableDot);
-        if (c == null) {
-            return;
-        }
-
-        Float2 pixel = relativeToAbsolutePixels(drawableDot.getLocationOnScreen());
-
-        graphics.setColor(c);
+    private void renderDot(int dotDrawSize, Float2 pixel) {
         graphics.fillOval(Math.round(pixel.x - dotDrawSize / 2f), Math.round(pixel.y - dotDrawSize / 2f),
                 dotDrawSize, dotDrawSize);
     }
 
-    public void renderText(DrawableText drawableText) {
+    private void renderText(String text, int fontSize, Float2 pixel) {
         //TODO http://stackoverflow.com/questions/27706197/how-can-i-center-graphics-drawstring-in-java
 
-        int fontSize = Math.round(drawableText.getSize());
-        Color c = colorBasedOnDistance(drawableText);
-        if (c == null) {
-            return;
-        }
-        Float2 pixel = relativeToAbsolutePixels(drawableText.getLocationOnScreen());
-
-        graphics.setColor(c);
         graphics.setFont(createFont(fontSize));
-        graphics.drawString(drawableText.getText(), Math.round(pixel.x), Math.round(pixel.y));
-        //TODO REMOVE DUPLICATE CODE !!! same as above but drawString instead of fillOval
+        graphics.drawString(text, Math.round(pixel.x), Math.round(pixel.y));
     }
 
     private Font createFont(int fontSize) {

--- a/src/com/wasd/lib3d/rendering/Renderer.java
+++ b/src/com/wasd/lib3d/rendering/Renderer.java
@@ -24,26 +24,30 @@ public class Renderer {
         centerY = height / 2;
     }
 
-    public void render(Drawable drawable){
+    public void render(Drawable drawable) {
         Color color = colorBasedOnDistance(drawable);
         if (color == null) {
             return;
         }
         graphics.setColor(color);
 
-        if(drawable instanceof DrawableLine){
+        //TODO refactor into something better, like Visitor pattern
+        if (drawable instanceof DrawableLine) {
             renderLine((DrawableLine) drawable);
-        } else if(drawable instanceof DrawableDot){
-            DrawableDot dotted = (DrawableDot)drawable;
+        } else if (drawable instanceof DrawableDot) {
+            DrawableDot drawableDot = (DrawableDot) drawable;
 
-            int size = Math.round(dotted.getSize());
-            Float2 positionPixel = relativeToAbsolutePixels(dotted.getLocationOnScreen());
+            int size = Math.round(drawableDot.getSize());
+            Float2 positionPixel = relativeToAbsolutePixels(drawableDot.getLocationOnScreen());
 
-            if(drawable instanceof DrawableText){
-                renderText(((DrawableText) drawable).getText(), size, positionPixel);
-            } else {
-                renderDot(size, positionPixel);
-            }
+            renderDot(size, positionPixel);
+        } else if (drawable instanceof DrawableText) {
+            DrawableText drawableText = (DrawableText) drawable;
+
+            int size = Math.round(drawableText.getSize());
+            Float2 positionPixel = relativeToAbsolutePixels(drawableText.getLocationOnScreen());
+
+            renderText(drawableText.getText(), size, positionPixel);
         }
     }
 

--- a/src/com/wasd/lib3d/shapes/Shape.java
+++ b/src/com/wasd/lib3d/shapes/Shape.java
@@ -13,8 +13,8 @@ import java.util.ArrayList;
 public abstract class Shape implements Renderable {
 
     //TODO array instead of List? As exact size is known
-    protected final ArrayList<Dot> dots;
-    protected final ArrayList<Line> lines;
+    final ArrayList<Dot> dots;
+    final ArrayList<Line> lines;
 
     public Shape(int numDots, int numLines) {
         dots = new ArrayList<>(numDots);

--- a/src/com/wasd/lib3d/shapes/Shape.java
+++ b/src/com/wasd/lib3d/shapes/Shape.java
@@ -43,13 +43,13 @@ public abstract class Shape implements Renderable {
         if (layer == Layer.DOTS) {
             for (Dot dot : dots) {
                 if (dot.getDrawable().shouldRender()) {
-                    renderer.renderDot(dot.getDrawable());
+                    renderer.render(dot.getDrawable());
                 }
             }
         } else if (layer == Layer.LINES) {
             for (Line line : lines) {
                 if (line.getDrawable().shouldRender()) {
-                    renderer.renderLine(line.getDrawable());
+                    renderer.render(line.getDrawable());
                 }
             }
         }

--- a/src/com/wasd/lib3d/shapes/primitives/Text.java
+++ b/src/com/wasd/lib3d/shapes/primitives/Text.java
@@ -45,7 +45,7 @@ public class Text implements PrimitiveShape<DrawableText>, Renderable {
         //TODO refactor
         if (layer == Layer.TEXTS) {
             if (drawable.shouldRender()) {
-                renderer.renderText(drawable);
+                renderer.render(drawable);
             }
         }
     }


### PR DESCRIPTION
Combined as much as possible of the renderLine(), renderDot(), renderText() methods into a smart render() method which first does the common Drawable things, then (depending on the determined type of Drawable) calls the appropriate, now much smaller, Drawable-specific method.
